### PR TITLE
feat(website): add metacheck page for metadata skeleton output

### DIFF
--- a/apps/angularlogos/src/app/app.component.html
+++ b/apps/angularlogos/src/app/app.component.html
@@ -32,9 +32,9 @@
         >Add your logo</a
       >
     </div>
-    <div class="logo-list">
-      <app-logos-list></app-logos-list>
-    </div>
+
+    <router-outlet></router-outlet>
+
     <div class="credits">
       <hr />
       <p>

--- a/apps/angularlogos/src/app/app.component.scss
+++ b/apps/angularlogos/src/app/app.component.scss
@@ -58,10 +58,6 @@
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
 }
 
-.logo-list {
-  flex: 1 1 auto;
-}
-
 .credits {
   flex: 0 0 auto;
   font-size: 0.8rem;

--- a/apps/angularlogos/src/app/app.module.ts
+++ b/apps/angularlogos/src/app/app.module.ts
@@ -9,12 +9,13 @@ import { LogosListComponent } from './logos-list/logos-list.component';
 import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SearchComponent } from './search/search.component';
+import { appRoutes } from './app.routes';
 
 @NgModule({
   declarations: [AppComponent, LogosListComponent, SearchComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot([], { initialNavigation: 'enabled' }),
+    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabled' }),
     BrowserAnimationsModule,
     ReactiveFormsModule,
     MatButtonModule,

--- a/apps/angularlogos/src/app/app.module.ts
+++ b/apps/angularlogos/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
+import { appRoutes } from './app.routes';
 import { AppComponent } from './app.component';
 import { RouterModule } from '@angular/router';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -9,10 +10,10 @@ import { LogosListComponent } from './logos-list/logos-list.component';
 import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SearchComponent } from './search/search.component';
-import { appRoutes } from './app.routes';
+import { MetacheckComponent } from './metacheck/metacheck.component';
 
 @NgModule({
-  declarations: [AppComponent, LogosListComponent, SearchComponent],
+  declarations: [AppComponent, LogosListComponent, SearchComponent, MetacheckComponent],
   imports: [
     BrowserModule,
     RouterModule.forRoot(appRoutes, { initialNavigation: 'enabled' }),

--- a/apps/angularlogos/src/app/app.routes.ts
+++ b/apps/angularlogos/src/app/app.routes.ts
@@ -1,0 +1,4 @@
+import { Routes } from '@angular/router';
+import { LogosListComponent } from './logos-list/logos-list.component';
+
+export const appRoutes: Routes = [{ path: '', component: LogosListComponent }];

--- a/apps/angularlogos/src/app/app.routes.ts
+++ b/apps/angularlogos/src/app/app.routes.ts
@@ -4,5 +4,6 @@ import { MetacheckComponent } from './metacheck/metacheck.component';
 
 export const appRoutes: Routes = [
   { path: '', component: LogosListComponent },
-  { path: 'metacheck', component: MetacheckComponent }
+  { path: 'metacheck', component: MetacheckComponent },
+  { path: '**', redirectTo: '/' }
 ];

--- a/apps/angularlogos/src/app/app.routes.ts
+++ b/apps/angularlogos/src/app/app.routes.ts
@@ -1,4 +1,8 @@
 import { Routes } from '@angular/router';
 import { LogosListComponent } from './logos-list/logos-list.component';
+import { MetacheckComponent } from './metacheck/metacheck.component';
 
-export const appRoutes: Routes = [{ path: '', component: LogosListComponent }];
+export const appRoutes: Routes = [
+  { path: '', component: LogosListComponent },
+  { path: 'metacheck', component: MetacheckComponent }
+];

--- a/apps/angularlogos/src/app/logos-list/logos-list.component.scss
+++ b/apps/angularlogos/src/app/logos-list/logos-list.component.scss
@@ -1,3 +1,7 @@
+:host {
+  flex: 1 1 auto;
+}
+
 .card-container {
   display: flex;
   flex-wrap: wrap;

--- a/apps/angularlogos/src/app/metacheck/metacheck.component.html
+++ b/apps/angularlogos/src/app/metacheck/metacheck.component.html
@@ -1,0 +1,4 @@
+<h2>Logos without metadata</h2>
+
+<strong>Count:</strong> {{ (logosWithoutMetadata$ | async)?.length }}
+<pre>{{ fullLogoMetadata$ | async | json }}</pre>

--- a/apps/angularlogos/src/app/metacheck/metacheck.component.spec.ts
+++ b/apps/angularlogos/src/app/metacheck/metacheck.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MetacheckComponent } from './metacheck.component';
+
+describe('MetacheckComponent', () => {
+  let component: MetacheckComponent;
+  let fixture: ComponentFixture<MetacheckComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [MetacheckComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MetacheckComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/angularlogos/src/app/metacheck/metacheck.component.ts
+++ b/apps/angularlogos/src/app/metacheck/metacheck.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { DataService } from '../shared/data.service';
+import { map, shareReplay } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-metacheck',
+  templateUrl: './metacheck.component.html',
+  styleUrls: ['./metacheck.component.scss']
+})
+export class MetacheckComponent implements OnInit {
+  logosWithoutMetadata$ = this.ds.getLogosWithoutMetadata().pipe(
+    map((logos) =>
+      logos.map((logo) => ({
+        metadataObject: { [logo.filename]: { name: logo.name, creator: '', description: '', website: '', license: '' } },
+        filename: logo.filename
+      }))
+    ),
+    shareReplay()
+  );
+
+  fullLogoMetadata$ = this.logosWithoutMetadata$.pipe(
+    map((logos) => logos.reduce((acc, item) => ({ ...acc, ...item.metadataObject }), {}))
+  );
+
+  constructor(private ds: DataService) {}
+
+  ngOnInit() {}
+}


### PR DESCRIPTION
route `/metacheck` now presents JSON output with all logos that don't have metadata. Should simplify the process of maintaining the metadata.

![Screen Shot 2020-01-22 at 23 37 30](https://user-images.githubusercontent.com/1683147/72940980-2d11e380-3d70-11ea-916c-bc4165a7cc12.png)
