### PR TITLE
feat(website): add random seed to image URL to work around CDN cache

### DIFF
--- a/apps/angularlogos/src/app/logos-list/logos-list.component.html
+++ b/apps/angularlogos/src/app/logos-list/logos-list.component.html
@@ -3,7 +3,7 @@
 <div class="card-container">
   <mat-card class="logo" *ngFor="let logo of logos$ | async">
     <mat-card-content>
-      <img [src]="logo.imageUrl" [title]="logo.name" height="100px" />
+      <img [src]="logo.imageUrl + randomSeed" [title]="logo.name" height="100px" />
     </mat-card-content>
     <mat-card-title>{{ logo.name }}</mat-card-title>
     <mat-card-actions>

--- a/apps/angularlogos/src/app/logos-list/logos-list.component.ts
+++ b/apps/angularlogos/src/app/logos-list/logos-list.component.ts
@@ -16,6 +16,8 @@ export class LogosListComponent implements OnInit {
   searchTerm$ = new Subject<string>();
   firstSearchTerm$: Observable<string>;
 
+  randomSeed = '?v=' + Math.floor(Math.random() * 10);
+
   constructor(private ds: DataService, private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit() {


### PR DESCRIPTION
temporarily closes #18

if this solves the problem we should think about (automatically) triggering a HTTP call once after the logo has been added. What we do now is to destroy the cache for every new request